### PR TITLE
Add Jest configuration and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ $ ./zip_artifacts.sh
 # → copyurl_<version>.zip generated in project root
 ```
 
+### Run tests
+
+```bash
+$ npm install
+$ npm test
+```
+
 ---
 
 ## Project structure (major files)

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [["@babel/preset-env", { targets: { node: "current" } }]],
+};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "copyurl",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.22.0",
+    "babel-jest": "^29.6.0",
+    "jest": "^29.6.0"
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -169,3 +169,5 @@ async function copyLink(tab, task) {
     }
   }
 }
+
+export { initializeMenus };

--- a/tests/Copy.test.js
+++ b/tests/Copy.test.js
@@ -1,0 +1,16 @@
+import { Copy } from '../src/modules/background/Copy.js';
+
+describe('Copy fallback', () => {
+  beforeEach(() => {
+    navigator.clipboard = {
+      writeText: jest.fn().mockRejectedValue(new Error('fail')),
+    };
+    document.execCommand = jest.fn().mockReturnValue(true);
+  });
+
+  test('falls back to execCommand when clipboard write fails', async () => {
+    await Copy('copyUrl');
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+});

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,0 +1,35 @@
+import { initializeMenus } from '../src/background.js';
+import { menus as defaultMenus } from '../src/modules/background/menus.js';
+
+describe('initializeMenus', () => {
+  beforeEach(() => {
+    global.chrome = {
+      storage: {
+        sync: {
+          get: jest.fn().mockResolvedValue({
+            contextMenus: [
+              { id: 'copyRichLink', active: false }
+            ]
+          }),
+          set: jest.fn().mockResolvedValue(),
+        },
+      },
+      contextMenus: {
+        create: jest.fn(),
+      },
+    };
+  });
+
+  test('applies stored menu states', async () => {
+    const expectedMenus = defaultMenus.map(m => ({ ...m }));
+    expectedMenus[0].active = false;
+    await initializeMenus();
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({ contextMenus: expectedMenus });
+    expect(chrome.contextMenus.create).toHaveBeenCalledTimes(expectedMenus.length);
+    expect(chrome.contextMenus.create).toHaveBeenCalledWith({
+      id: expectedMenus[0].id,
+      title: expectedMenus[0].title,
+      visible: expectedMenus[0].active,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with Babel
- export `initializeMenus` for testing
- add unit tests for background menu initialization and clipboard fallback
- document how to run tests

## Testing
- `npx jest` *(fails: unable to fetch packages)*