### PR TITLE
Fix context menu initialization

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -75,7 +75,7 @@ function initializeCache() {
 }
 
 function initializeMenus(details) {
-  chrome.storage.sync.get("contextMenus").then((items) => {
+  return chrome.storage.sync.get("contextMenus").then((items) => {
     let contextMenus = defaultMenus;
     if (items && items.contextMenus) {
       for (const menu of items.contextMenus) {
@@ -86,13 +86,13 @@ function initializeMenus(details) {
               break;
             }
           }
-          break;
         }
       }
     }
-    chrome.storage.sync
+    return chrome.storage.sync
       .set({ contextMenus })
-      .then(createContextMenus(contextMenus));
+      .then(() => createContextMenus(contextMenus))
+      .catch((err) => console.error("Error saving context menus:", err));
   });
 }
 


### PR DESCRIPTION
## Summary
- return `chrome.storage.sync.set` promise
- log errors when saving context menus
- remove incorrect loop break

## Testing
- `git status --short`