### PR TITLE
Fix grammar in Copy.js comment

### DIFF
--- a/src/modules/background/Copy.js
+++ b/src/modules/background/Copy.js
@@ -1,5 +1,5 @@
 "use strict";
-// This script tend to run in the context of the user's tab
+// This script tends to run in the context of the user's tab
 // by chrome.scripting.executeScript().
 
 async function Copy(task, showNotification = true) {


### PR DESCRIPTION
## Summary
- correct small grammatical error in `Copy.js`

## Testing
- `npm test` *(fails: Could not read package.json)*