### PR TITLE
Fix context menu initialization

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -80,19 +80,16 @@ function initializeMenus(details) {
     if (items && items.contextMenus) {
       for (const menu of items.contextMenus) {
         if (menu.active !== undefined) {
-          for (const contextMenu of contextMenus) {
-            if (contextMenu.id === menu.id) {
-              contextMenu.active = menu.active;
-              break;
-            }
+          const target = contextMenus.find((m) => m.id === menu.id);
+          if (target) {
+            target.active = menu.active;
           }
-          break;
         }
       }
     }
     chrome.storage.sync
       .set({ contextMenus })
-      .then(createContextMenus(contextMenus));
+      .then(() => createContextMenus(contextMenus));
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure all stored context menu states are applied
- correctly chain createContextMenus after storage set

## Testing
- `npm test` *(fails: jest not found)*