### PR TITLE
Add copy history panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Chrome extension that lets you copy the current page URL (and title) in multiple
 | **HTML link** | `<a href="https://example.com">https://example.com</a>` | `<a href="https://example.com">https://example.com</a>` |
 | **HTML link + title** | `<a href="https://example.com">Example Site</a>` | `<a href="https://example.com">Example Site</a>` |
 | **Title only** | `Example Site` | Example Site |
+| **Copy history** | View recent copies in the options page | |
 
 Enable/disable each item from the **Options** page.
 

--- a/src/background.js
+++ b/src/background.js
@@ -2,6 +2,7 @@
 
 import { Copy } from "./modules/background/Copy.js";
 import { menus as defaultMenus } from "./modules/background/menus.js";
+import { addToHistory } from "./modules/background/history.js";
 
 // Cache for the default format and notification preference - initialized with default values
 let cachedDefaultFormat = 'copyRichLink';
@@ -13,6 +14,7 @@ chrome.runtime.onStartup.addListener(initializeCache);
 
 // for option change events
 chrome.runtime.onMessage.addListener(refreshMenus);
+chrome.runtime.onMessage.addListener(handleHistoryMessage);
 // contextmenus click event
 chrome.contextMenus.onClicked.addListener(runTaskOfClickedMenu);
 // icon click event
@@ -130,6 +132,14 @@ function updateContextMenus() {
       });
     }
   });
+}
+
+function handleHistoryMessage(message, sender, sendResponse) {
+  if (message.type !== 'addHistory') return;
+  addToHistory({ url: message.url, title: message.title })
+    .then(() => sendResponse({ result: 'added' }))
+    .catch(() => sendResponse({ result: 'error' }));
+  return true;
 }
 
 function runTaskOfClickedMenu(info, tab) {

--- a/src/modules/background/Copy.js
+++ b/src/modules/background/Copy.js
@@ -5,6 +5,18 @@
 async function Copy(task, showNotification = true) {
   // Store showNotification in a variable visible to all internal functions
   const shouldShowNotification = showNotification;
+
+  async function recordHistory() {
+    try {
+      await chrome.runtime.sendMessage({
+        type: 'addHistory',
+        url: location.href,
+        title: document.title
+      });
+    } catch (e) {
+      console.debug('failed to record history', e);
+    }
+  }
   async function copyUrl() {
     const content = location.href;
     await writeToClipboard(content);
@@ -179,6 +191,8 @@ async function Copy(task, showNotification = true) {
     default:
       console.debug("not implemented");
   }
+
+  await recordHistory();
 }
 
 export { Copy };

--- a/src/modules/background/history.js
+++ b/src/modules/background/history.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const MAX_HISTORY = 20;
+
+async function addToHistory({ url, title }) {
+  const { copyHistory = [] } = await chrome.storage.local.get({ copyHistory: [] });
+  const newEntry = { url, title, timestamp: Date.now() };
+  const updated = [newEntry, ...copyHistory].slice(0, MAX_HISTORY);
+  await chrome.storage.local.set({ copyHistory: updated });
+}
+
+export { addToHistory, MAX_HISTORY };

--- a/src/options/history.html
+++ b/src/options/history.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Copy History</title>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="options.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Copy History</h1>
+    </header>
+    <main>
+      <ul id="history-list"></ul>
+    </main>
+    <footer>
+      <a href="index.html">Back to Options</a>
+    </footer>
+  </div>
+  <script src="history.js"></script>
+</body>
+</html>

--- a/src/options/history.js
+++ b/src/options/history.js
@@ -1,0 +1,16 @@
+"use strict";
+
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('history-list');
+  chrome.storage.local.get({ copyHistory: [] }).then(({ copyHistory }) => {
+    copyHistory.forEach(({ url, title }) => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = url;
+      a.textContent = title || url;
+      a.target = '_blank';
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  });
+});

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -38,6 +38,7 @@
 
       <footer>
         <p>Copy Rich URL - Easily copy links in various formats</p>
+        <p><a href="history.html">View Copy History</a></p>
       </footer>
     </div>
     <script src="options.js"></script>

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,0 +1,27 @@
+import { addToHistory, MAX_HISTORY } from '../src/modules/background/history.js';
+
+describe('addToHistory', () => {
+  beforeEach(() => {
+    global.chrome = {
+      storage: {
+        local: {
+          get: jest.fn().mockResolvedValue({ copyHistory: [] }),
+          set: jest.fn().mockResolvedValue(),
+        },
+      },
+    };
+  });
+
+  test('adds entry and trims history', async () => {
+    const existing = Array(MAX_HISTORY).fill({ url: 'old', title: 'old' });
+    chrome.storage.local.get.mockResolvedValue({ copyHistory: existing });
+
+    await addToHistory({ url: 'https://example.com', title: 'Example' });
+
+    expect(chrome.storage.local.get).toHaveBeenCalledWith({ copyHistory: [] });
+    expect(chrome.storage.local.set).toHaveBeenCalled();
+    const updated = chrome.storage.local.set.mock.calls[0][0].copyHistory;
+    expect(updated.length).toBe(MAX_HISTORY);
+    expect(updated[0].url).toBe('https://example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- track copied links in `chrome.storage.local`
- expose a new history page accessible from options
- support background message for history recording
- test history addition behavior

## Testing
- `npm test` *(fails: jest not found)*