### PR TITLE
Add GitHub Actions for Node tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,19 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 20
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,4 @@
 module.exports = {
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
+  setupFiles: ['./tests/setup.js'],
 };

--- a/src/background.js
+++ b/src/background.js
@@ -7,31 +7,32 @@ import { menus as defaultMenus } from "./modules/background/menus.js";
 let cachedDefaultFormat = 'copyRichLink';
 let cachedShowNotification = true;
 
-// initialize
-chrome.runtime.onInstalled.addListener(initializeExtension);
-chrome.runtime.onStartup.addListener(initializeCache);
+// initialize if chrome API is available (allows importing in test environment)
+if (typeof chrome !== 'undefined') {
+  chrome.runtime.onInstalled.addListener(initializeExtension);
+  chrome.runtime.onStartup.addListener(initializeCache);
 
-// for option change events
-chrome.runtime.onMessage.addListener(refreshMenus);
-// contextmenus click event
-chrome.contextMenus.onClicked.addListener(runTaskOfClickedMenu);
-// icon click event
-// use the default format from storage
-chrome.action.onClicked.addListener(tab => copyLink(tab, cachedDefaultFormat));
+  // for option change events
+  chrome.runtime.onMessage.addListener(refreshMenus);
+  // contextmenus click event
+  chrome.contextMenus.onClicked.addListener(runTaskOfClickedMenu);
+  // icon click event - use the default format from storage
+  chrome.action.onClicked.addListener(tab => copyLink(tab, cachedDefaultFormat));
 
-// Listen for changes to the default format and notification preference
-chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'sync') {
-    if (changes.defaultFormat) {
-      cachedDefaultFormat = changes.defaultFormat.newValue;
-      console.log('Default format updated in cache:', cachedDefaultFormat);
+  // Listen for changes to the default format and notification preference
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'sync') {
+      if (changes.defaultFormat) {
+        cachedDefaultFormat = changes.defaultFormat.newValue;
+        console.log('Default format updated in cache:', cachedDefaultFormat);
+      }
+      if (changes.showNotification) {
+        cachedShowNotification = changes.showNotification.newValue;
+        console.log('Notification preference updated in cache:', cachedShowNotification);
+      }
     }
-    if (changes.showNotification) {
-      cachedShowNotification = changes.showNotification.newValue;
-      console.log('Notification preference updated in cache:', cachedShowNotification);
-    }
-  }
-});
+  });
+}
 // for debug convenience
 // chrome.action.onClicked.addListener((tab) =>
 //   chrome.scripting.executeScript({

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,34 @@
+// Minimal DOM stubs for tests
+global.document = {
+  title: 'Example',
+  createElement: (tag) => {
+    return {
+      tagName: tag.toUpperCase(),
+      style: {},
+      setAttribute: jest.fn(),
+      append: jest.fn(),
+      appendChild: jest.fn(),
+      remove: jest.fn(),
+      select: jest.fn(),
+      innerText: '',
+      textContent: '',
+      outerHTML: `<${tag}></${tag}>`,
+    };
+  },
+  body: {
+    append: jest.fn(),
+    appendChild: jest.fn(),
+    removeChild: jest.fn(),
+  },
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  execCommand: jest.fn(),
+};
+
+global.location = { href: 'https://example.com' };
+
+global.navigator = {};
+
+global.Blob = global.Blob || function(parts, options) { this.parts = parts; this.type = options.type; };
+
+global.ClipboardItem = global.ClipboardItem || function(items) { this.items = items; };


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- add minimal DOM stubs for Jest
- use setup file in Jest config
- guard chrome API in background script so tests can import it

## Testing
- `npm test`