### PR TITLE
Improve error handling for restricted pages

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -83,5 +83,14 @@
   },
   "notification_copied": {
     "message": "Copied!"
+  },
+  "notification_error_clipboard": {
+    "message": "Failed to copy to clipboard"
+  },
+  "notification_error_restricted": {
+    "message": "Cannot copy from this page"
+  },
+  "notification_error_permission": {
+    "message": "Clipboard access denied"
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -83,5 +83,14 @@
   },
   "notification_copied": {
     "message": "コピーしました！"
+  },
+  "notification_error_clipboard": {
+    "message": "クリップボードへのコピーに失敗しました"
+  },
+  "notification_error_restricted": {
+    "message": "このページからはコピーできません"
+  },
+  "notification_error_permission": {
+    "message": "クリップボードアクセスが拒否されました"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   "action": {
     "default_title": "__MSG_default_title__"
   },
-  "permissions": ["contextMenus", "storage", "activeTab", "scripting"],
+  "permissions": ["contextMenus", "storage", "activeTab", "scripting", "notifications"],
   "icons": {
     "128": "img/copyurl_128.png"
   }


### PR DESCRIPTION
Fixes #17

This PR improves error handling by adding user notifications for different failure types when copying fails on restricted pages like chrome:// URLs.

## Changes
- Add error notification messages to i18n files (en/ja)
- Enhance Copy.js with error-specific notification system
- Add visual distinction for error notifications (red background, longer duration)
- Improve error detection and categorization in clipboard operations
- Add Chrome notifications for restricted page errors in background.js
- Add "notifications" permission to manifest.json

Generated with [Claude Code](https://claude.ai/code)