### PR TITLE
Add keyboard shortcuts for copy actions

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -18,6 +18,8 @@ if (typeof chrome !== 'undefined') {
   chrome.contextMenus.onClicked.addListener(runTaskOfClickedMenu);
   // icon click event - use the default format from storage
   chrome.action.onClicked.addListener(tab => copyLink(tab, cachedDefaultFormat));
+  // keyboard shortcuts via commands API
+  chrome.commands.onCommand.addListener(runCommandShortcut);
 
   // Listen for changes to the default format and notification preference
   chrome.storage.onChanged.addListener((changes, area) => {
@@ -132,6 +134,35 @@ function updateContextMenus() {
 
 function runTaskOfClickedMenu(info, tab) {
   const task = info.menuItemId;
+  copyLink(tab, task);
+}
+
+async function runCommandShortcut(command) {
+  // Get the current active tab
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  
+  if (!tab) {
+    console.warn('No active tab found for keyboard shortcut');
+    return;
+  }
+
+  // Map command names to menu IDs
+  let task;
+  switch (command) {
+    case 'copy-rich-link':
+      task = 'copyRichLink';
+      break;
+    case 'copy-url-only':
+      task = 'copyUrl';
+      break;
+    case 'copy-markdown':
+      task = 'copyUrlWithTitleAsMarkdown';
+      break;
+    default:
+      console.warn(`Unknown command: ${command}`);
+      return;
+  }
+
   copyLink(tab, task);
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,6 +13,29 @@
     "default_title": "__MSG_default_title__"
   },
   "permissions": ["contextMenus", "storage", "activeTab", "scripting"],
+  "commands": {
+    "copy-rich-link": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+C",
+        "mac": "Command+Shift+C"
+      },
+      "description": "Copy rich link (title + URL)"
+    },
+    "copy-url-only": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+U",
+        "mac": "Command+Shift+U"
+      },
+      "description": "Copy URL only"
+    },
+    "copy-markdown": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+M",
+        "mac": "Command+Shift+M"
+      },
+      "description": "Copy as Markdown link"
+    }
+  },
   "icons": {
     "128": "img/copyurl_128.png"
   }

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -33,3 +33,22 @@ describe('initializeMenus', () => {
     });
   });
 });
+
+describe('keyboard commands', () => {
+  test('commands are defined in manifest', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const manifestPath = path.join(__dirname, '../src/manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    
+    expect(manifest.commands).toBeDefined();
+    expect(manifest.commands['copy-rich-link']).toBeDefined();
+    expect(manifest.commands['copy-url-only']).toBeDefined();
+    expect(manifest.commands['copy-markdown']).toBeDefined();
+    
+    // Check keyboard shortcuts
+    expect(manifest.commands['copy-rich-link'].suggested_key.default).toBe('Ctrl+Shift+C');
+    expect(manifest.commands['copy-url-only'].suggested_key.default).toBe('Ctrl+Shift+U');
+    expect(manifest.commands['copy-markdown'].suggested_key.default).toBe('Ctrl+Shift+M');
+  });
+});


### PR DESCRIPTION
Implements configurable keyboard shortcuts for quick copying without mouse interaction.

## Changes
- Add Chrome commands API support with 3 keyboard shortcuts
- Ctrl+Shift+C (Cmd+Shift+C on Mac): Copy rich link
- Ctrl+Shift+U (Cmd+Shift+U on Mac): Copy URL only
- Ctrl+Shift+M (Cmd+Shift+M on Mac): Copy Markdown link
- Integrate with existing copy functionality and format system
- Add test coverage for command configuration

Fixes #20

Generated with [Claude Code](https://claude.ai/code)