### PR TITLE
docs: add Repository Guidelines (AGENTS.md); chore(background): promise-returning initializeMenus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,4 +12,47 @@ This repository contains a Chrome extension built with Node.js. Please follow th
 3. **General Notes**
    - Do not commit `node_modules` or other generated files.
    - Distribution zips can be created via `./zip_artifacts.sh` but are not required for pull requests.
+# Repository Guidelines
+
+This repository hosts a Chrome extension (Manifest V3) that copies the current page URL and title in multiple formats (rich text, Markdown, HTML, etc.). Use this guide to develop, test, and contribute changes efficiently.
+
+## Project Structure & Module Organization
+- `src/manifest.json`: MV3 manifest and permissions.
+- `src/background.js`: Service worker; context menus, icon click, settings cache.
+- `src/modules/background/Copy.js`: Clipboard logic and format converters.
+- `src/modules/background/menus.js`: Default context menu definitions.
+- `src/options/`: Options page HTML/CSS/JS.
+- `src/_locales/{en,ja}/messages.json`: i18n strings.
+- `tests/`: Jest tests and minimal DOM stubs.
+- `zip_artifacts.sh`: Build a distributable ZIP (uses `jq`).
+
+## Build, Test, and Development Commands
+- Install: `npm install`
+- Test: `npm test` (runs Jest via Babel).
+- Package: `./zip_artifacts.sh` → `copyurl_<version>.zip` in repo root.
+- Load locally: Chrome → Extensions → Developer mode → Load unpacked → select `src/`.
+
+## Coding Style & Naming Conventions
+- JavaScript (ES Modules), 2‑space indent, semicolons, double quotes.
+- Keep modules small and single‑purpose; prefer pure functions for logic.
+- Filenames: `PascalCase.js` for modules under `modules/`, kebab/flat for others as existing.
+- No new global state in content pages; use `chrome.storage.sync` for settings.
+- No generated artifacts in VCS (`node_modules/`, build outputs).
+
+## Testing Guidelines
+- Framework: Jest + `babel-jest` (`tests/` contains `*.test.js`).
+- Run locally with `npm test`; add tests for new logic/bug fixes.
+- Prefer unit tests around formatters and menu/state transitions.
+- Optional: `jest --coverage` if you want a local report (no strict threshold enforced).
+
+## Commit & Pull Request Guidelines
+- Commits: Imperative mood, concise scope, reference issues (`Fix: handle restricted pages (#123)`).
+- Before PR: run `npm install && npm test`; ensure tests pass.
+- PR description: purpose, user‑visible changes, risks, screenshots (options UI) when relevant, and list modified files.
+- Do not commit `node_modules` or distribution ZIPs.
+
+## Security & Configuration Tips
+- Keep permissions in `manifest.json` minimal; avoid new permissions without justification.
+- Clipboard operations must handle restricted pages gracefully (see `background.js` error handling).
+- i18n: add new keys to both `en` and `ja` locales.
 

--- a/src/background.js
+++ b/src/background.js
@@ -76,7 +76,8 @@ function initializeCache() {
 }
 
 function initializeMenus(details) {
-  chrome.storage.sync.get("contextMenus").then((items) => {
+  // Return the promise chain so callers (and tests) can await completion
+  return chrome.storage.sync.get("contextMenus").then((items) => {
     let contextMenus = defaultMenus;
     if (items && items.contextMenus) {
       for (const menu of items.contextMenus) {
@@ -88,9 +89,12 @@ function initializeMenus(details) {
         }
       }
     }
-    chrome.storage.sync
+    return chrome.storage.sync
       .set({ contextMenus })
-      .then(() => createContextMenus(contextMenus));
+      .then(() => {
+        createContextMenus(contextMenus);
+        return contextMenus;
+      });
   });
 }
 


### PR DESCRIPTION
Summary
- Add AGENTS.md: concise contributor guide titled 'Repository Guidelines' (structure, commands, style, tests, PR process, security).
- background.js: make initializeMenus return a Promise so tests can await menu creation reliably.

Files changed
- AGENTS.md (new contributor guide)
- src/background.js (return promise from initializeMenus)

Testing
- Ran npm install && npm test. Both suites pass here; sandbox may show EPERM on Jest worker shutdown, but tests pass.

Notes
- No changes to manifest or runtime behavior beyond returning a promise from initializeMenus.
- Did not commit node_modules or distribution artifacts.

Review
- Please confirm wording in AGENTS.md.
